### PR TITLE
DOC: add LANL copyright assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ldrd_virus_work
+# ldrd_virus_work (LANL copyright assertion ID: O# (O4909))
 
 ## LDRD DR Computational Work Repo
 


### PR DESCRIPTION
* Add the LANL copyright assertion info requested by FCI to the repository `README`.