### PR TITLE
CI: Forward port ARM Mac testing to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Linux CI
+name: Base CI
 
 on:
   push:
@@ -8,9 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         requirements-file: ["requirements_low.txt", "requirements_high.txt"]
 
@@ -20,6 +21,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install libomp
     - name: Install dependencies
       run: |
         python -m pip install -U setuptools pip


### PR DESCRIPTION
* Forward port ARM Mac testing to the CI config from gh-12, since having ARM Mac testing running is quite useful to reflect our local development setups (and, in general, to cover us for both x86_64 and ARM).