### PR TITLE
BUG: plot_family_heatmap index handling

### DIFF
--- a/viral_seq/data/make_data_summary_plots.py
+++ b/viral_seq/data/make_data_summary_plots.py
@@ -38,10 +38,10 @@ def plot_family_heatmap(
         filepath to output generated plot's source data
     """
     # get family counts
-    df_train = pd.read_csv(train_file, index_col=0)[["Species", target_column]]
+    df_train = pd.read_csv(train_file, index_col=False)[["Species", target_column]]
     train_true = _get_family_counts(df_train.loc[df_train[target_column]])
     train_false = _get_family_counts(df_train.loc[~df_train[target_column]])
-    df_test = pd.read_csv(test_file, index_col=0)[["Species", target_column]]
+    df_test = pd.read_csv(test_file, index_col=False)[["Species", target_column]]
     test_true = _get_family_counts(df_test.loc[df_test[target_column]])
     test_false = _get_family_counts(df_test.loc[~df_test[target_column]])
     # format DataFrame

--- a/viral_seq/tests/test_data.py
+++ b/viral_seq/tests/test_data.py
@@ -142,7 +142,8 @@ def test_get_family_counts_missing():
 
 
 @pytest.mark.parametrize("target_column", ["Human Host", "other"])
-def test_plot_family_heatmap(tmpdir, target_column):
+@pytest.mark.parametrize("numeric_index", [True, False])
+def test_plot_family_heatmap(tmpdir, target_column, numeric_index):
     expected_plot = files("viral_seq.tests.expected") / (
         f"test_plot_family_heatmap_{target_column}.png".replace(" ", "_")
     )
@@ -159,8 +160,8 @@ def test_plot_family_heatmap(tmpdir, target_column):
     df_train[target_column] = rng.integers(0, 2, size=len(df_train), dtype=bool)
     df_test[target_column] = rng.integers(0, 2, size=len(df_test), dtype=bool)
     with tmpdir.as_cwd():
-        df_train.to_csv("train_file.csv")
-        df_test.to_csv("test_file.csv")
+        df_train.to_csv("train_file.csv", index=numeric_index)
+        df_test.to_csv("test_file.csv", index=numeric_index)
         data_summary.plot_family_heatmap(
             "train_file.csv", "test_file.csv", target_column
         )


### PR DESCRIPTION
* Fixes gh-14.

* Add a regression test for the failure of `plot_family_heatmap()` to handle input data files where there is no numeric index.

* Add a small patch to `plot_family_heatmap()` to resolve the matter.