### PR TITLE
DOC, ENH: summarize dataset changes vs. Mollentze

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,25 @@ Student t-test: t_stat -7.022, p-value 0.000
 
 ```
 
+Comparing Dataset vs. Mollentze for LDRD manuscript
+===================================================
+
+To compare the "human host" infection status changes
+for records in our new dataset vs. the original
+dataset used by Mollentze, there is a small script
+at `viral_seq/data` that can be executed:
+
+`python summarize_changes_v_mollentze.py`
+
+Which will output a summary of the human host infection
+status changes:
+
+```
+Number of records for which human infection status switched from False to True: 21
+Number of records for which human infection status switched from True to False: 0
+```
+
+
 
 About Licensing
 ===============

--- a/viral_seq/data/summarize_changes_v_mollentze.py
+++ b/viral_seq/data/summarize_changes_v_mollentze.py
@@ -1,0 +1,40 @@
+"""
+The purpose of this module is to compare
+the human vs. not-human infection status of
+records in our improved dataset vs. the original
+Mollentze dataset. We just want a few basic measures
+of what has changed vs. the original dataset.
+"""
+
+import pandas as pd
+
+
+def main():
+    orig_train_df = pd.read_csv(
+        "Mollentze_Training.csv", usecols=["Accessions", "Human Host"]
+    )
+    new_train_df = pd.read_csv("Relabeled_Train.csv", usecols=["Accessions", "human"])
+    false_to_true = 0
+    true_to_false = 0
+    for new_row in new_train_df.itertuples():
+        new_accession = new_row[1]
+        new_human_infection = new_row[2]
+        old_human_infection = orig_train_df[
+            orig_train_df["Accessions"] == new_accession
+        ]["Human Host"].values.item()
+        if (not old_human_infection) and new_human_infection:
+            false_to_true += 1
+        elif old_human_infection and (not new_human_infection):
+            true_to_false += 1
+    print(
+        "Number of records for which human infection status switched from "
+        f"False to True: {false_to_true}"
+    )
+    print(
+        "Number of records for which human infection status switched from "
+        f"True to False: {true_to_false}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Add a simple script (and docs) for quantifying the changes in human host infection status vs. the original data used by Mollentze. Most of the changes are related to more recently-available literature evidence of infection (I think).

* The results indicate that 21 viruses have had their human infection status updated from `False` to `True`, while no viruses have been relabeled in the opposite direction.