### PR TITLE
ENH: smoothed relative entropy

### DIFF
--- a/viral_seq/tests/test_data.py
+++ b/viral_seq/tests/test_data.py
@@ -208,14 +208,15 @@ def test__plot_family_heatmap(tmpdir):
         (
             # when one viral family is completely
             # absent from one of the splits, the
-            # KL divergence is infinite
+            # KL divergence is large, but finite
+            # because we are using additive smoothing
             {
                 "Train Human Host": [1, 2],
                 "Train Not Human Host": [0, 1],
                 "Test Human Host": [2, 0],
                 "Test Not Human Host": [3, 0],
             },
-            np.inf,
+            16.187193,
         ),
         (
             # when the viral families are perfectly


### PR DESCRIPTION
* Fixes gh-30.

* Adjust the `relative_entropy_viral_families()` function and its associated testing to use additive smoothing, such that when one of the compared datasets lacks class representation the relative entropy remains finite.

* I spot checked that two incantations matched their values cited in the manuscript:

  - (mammal shuffled) `0.069` from `python viral_seq/run_workflow.py --cache 0 --features 0 --feature-selection skip -tr Relabeled_Train_Mammal_Shuffled.csv -ts Relabeled_Test_Mammal_Shuffled.csv -tc "mammal"`

  - (mammal) `3.004` from `python viral_seq/run_workflow.py --cache 0 --features 0 --feature-selection skip -tr Relabeled_Train.csv -ts Relabeled_Test.csv -tc "mammal"`