### PR TITLE
DOC: correct the O# in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ldrd_virus_work (LANL copyright assertion ID: O# (O4909))
+# ldrd_virus_work (LANL copyright assertion ID: O# (O4904))
 
 ## LDRD DR Computational Work Repo
 


### PR DESCRIPTION
* Fixes gh-34.

* Per instructions provided by LANL FCI by email this morning, fix up the O# used in our `README` to match their records for open sourcing.