### PR TITLE
MAINT: limit estimator concurrency

### DIFF
--- a/ci/requirements_high.txt
+++ b/ci/requirements_high.txt
@@ -19,6 +19,7 @@ pandas==2.2.3
 pandas-stubs==2.0.2.230605
 Pillow==11.0.0
 polars==1.11.0
+psutil==7.1.3
 pyarrow==18.0.0
 Pygments==2.15.1
 pyparsing==3.1.0

--- a/ci/requirements_high.txt
+++ b/ci/requirements_high.txt
@@ -39,6 +39,7 @@ taxonomy_ranks==0.0.10
 tensorboardX==2.6.2.2
 threadpoolctl==3.1.0
 tqdm==4.66.5
+types-psutil==7.0.0.20251116
 types-pytz==2023.3.0.0
 types-seaborn==0.13.2.20250111
 types-shapely==2.0.0.20241221

--- a/ci/requirements_low.txt
+++ b/ci/requirements_low.txt
@@ -39,6 +39,7 @@ tensorboardX==2.6.2.2
 taxonomy_ranks==0.0.10
 threadpoolctl==3.1.0
 tqdm==4.65.0
+types-psutil==7.0.0.20251116
 types-pytz==2023.3.0.0
 types-shapely==2.0.0.20241221
 types-seaborn==0.13.2.20250111

--- a/ci/requirements_low.txt
+++ b/ci/requirements_low.txt
@@ -19,6 +19,7 @@ pandas==2.2.3
 pandas-stubs==2.0.2.230605
 Pillow==11.0.0
 polars==0.19.2
+psutil==7.1.3
 pyarrow==18.0.0
 Pygments==2.15.1
 pyparsing==3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 isg = ['pybiomart>=0.2.0']
-dev = ['mypy==1.3.0', 'black==23.3.0', 'ruff==0.8.1', 'pandas-stubs', 'types-seaborn', 'types-shapely', 'types-tqdm', 'pytest', 'pytest-cov', 'hypothesis', 'pytest-mock']
+dev = ['mypy==1.3.0', 'black==23.3.0', 'ruff==0.8.1', 'pandas-stubs', 'types-seaborn', 'types-shapely', 'types-tqdm', 'pytest', 'pytest-cov', 'hypothesis', 'pytest-mock', 'types-psutil']
 [tool.setuptools]
 packages=['viral_seq']
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "numpy>=2.1.0",
     "pandas>=2.2.3",
     "polars>=0.19.2",
+    "psutil>=7.1.3",
     "pyarrow>=18.0.0",
     "optuna>=3.6.1",
     "ray>=2.48.0",

--- a/viral_seq/run_workflow.py
+++ b/viral_seq/run_workflow.py
@@ -17,6 +17,7 @@ from urllib.error import URLError
 import polars as pl
 import ast
 import numpy as np
+import psutil
 from glob import glob
 from sklearn.ensemble import RandomForestClassifier, ExtraTreesClassifier
 from sklearn.metrics import roc_auc_score, auc, roc_curve
@@ -2164,6 +2165,10 @@ if __name__ == "__main__":
         # TODO: add CLI option for determining which classifiers to train
         # TODO: perform model parameter optimization (see issue #139)
         n_folds = 5
+        # limit concurrency for some estimators to the number
+        # of physical cores; see:
+        # https://github.com/lanl/ldrd_virus_work/issues/39#issuecomment-3358030424
+        physical_cores = psutil.cpu_count(logical=False)
         classifier_parameters = {
             "RandomForestClassifier": {
                 "clfr": RandomForestClassifier(),
@@ -2175,7 +2180,7 @@ if __name__ == "__main__":
             },
             "XGBClassifier": {
                 "clfr": XGBClassifier(),
-                "params": {"n_estimators": 10000, "n_jobs": -1},
+                "params": {"n_estimators": 10000, "n_jobs": physical_cores},
             },
             # LGBM parameters determined using suggestion from:
             # https://stackoverflow.com/questions/71285022/why-lightgbm-python-package-gives-bad-prediction-using-for-regression-task
@@ -2186,7 +2191,7 @@ if __name__ == "__main__":
                     "min_data_in_leaf": 1,
                     "boosting_type": "dart",
                     "n_estimators": 1000,
-                    "n_jobs": -1,
+                    "n_jobs": physical_cores,
                 },
             },
         }

--- a/viral_seq/run_workflow.py
+++ b/viral_seq/run_workflow.py
@@ -2172,11 +2172,11 @@ if __name__ == "__main__":
         classifier_parameters = {
             "RandomForestClassifier": {
                 "clfr": RandomForestClassifier(),
-                "params": {"n_estimators": 10000, "n_jobs": -1},
+                "params": {"n_estimators": 10000, "n_jobs": physical_cores},
             },
             "ExtraTreesClassifier": {
                 "clfr": ExtraTreesClassifier(),
-                "params": {"n_estimators": 10000, "n_jobs": -1},
+                "params": {"n_estimators": 10000, "n_jobs": physical_cores},
             },
             "XGBClassifier": {
                 "clfr": XGBClassifier(),


### PR DESCRIPTION
* Related to the discussion in gh-39, where some DTRA workflow incantations were taking on the order of 90+ hours to run on a Linux box (i.e., `gp160.lanl.gov`) that has many cores/threads, which is far too slow to be practical.

* Adam had originally proposed to limit concurrency by hard coding the number of threads to use for XGBoost and LGBM estimators to 16, but there were a few issues with that solution:

1) 16 is a fairly arbitrary number of threads in the grand scheme of things, and may not scale well on many machines, so I've replaced that approach with automatic counting of the number of physical cores and usage of that number of threads for XGB and LGBM in the DTRA workflow. This required addition of a new dependency, `psutil`.

2) Adam proposed using `thread` to control the concurrency for `XGBClassifier` at the same time as using `n_jobs`, which is not only confusing, but also deprecated by the xgboost team 8 years ago: https://github.com/dmlc/xgboost/releases/tag/v0.7
I don't know why this was suggested, and I didn't receive a response from Adam, but it seems sensible to try the modern `n_jobs` rather than both options at the same time, especially when one of them is deprecated.

3) Adam proposed using `num_threads` and `n_jobs` at the same time for controlling the concurrency of LGBM. For many of the same reasons, this is confusing to me without a clear justification, the latest docs only show `n_jobs` for `LGBMClassifier` and that is the typical `sklearn` estimator API, so again let's try to use `n_jobs` here.

* Before this is merged, it should be confirmed that one of the slow/problem incantations runs in a reasonable amount of time on both an ARM Mac and on gp160.

I started one of the previously-slow (90+ hour) incantations in a `gp160` screen session this morning: `time python ../viral_seq/run_workflow.py --cache extract --cache-tarball dtra_cache.tar.gz --optimize none --train-file receptor_training.csv --test-file none --workflow DTRA --target-column IG --mapping-method jurgen_schmidt --n_seeds 20 -s surface_exposed`.

Likewise with the same incantation on this branch on ARM Mac locally. I'll check back later to report how long the runs took to execute.