### PR TITLE
WIP, ENH: draft of ProtBert embeddings

### DIFF
--- a/viral_seq/analysis/get_features.py
+++ b/viral_seq/analysis/get_features.py
@@ -1,3 +1,4 @@
+import re
 from functools import cache
 from collections import defaultdict
 from Bio.Data.CodonTable import standard_dna_table
@@ -7,6 +8,8 @@ from typing import Any
 import pandas as pd
 import numpy as np
 import scipy.stats
+from transformers import BertTokenizer, BertModel
+import torch
 
 codontab = standard_dna_table.forward_table.copy()  # type: ignore
 for codon in standard_dna_table.stop_codons:  # type: ignore
@@ -53,6 +56,58 @@ def get_kmers(records, k=10, kmer_type="AA"):
                 for kmer in Sequence(str(this_seq)).iter_kmers(k, overlap=True):
                     kmers["kmer_" + kmer_type + "_" + str(kmer)] += 1
     return kmers
+
+
+def get_bert_embeddings(records):
+    print("start of get_bert_embeddings")
+    MODEL_NAME = "Rostlab/prot_bert_bfd"
+    tokenizer = BertTokenizer.from_pretrained(MODEL_NAME, do_lower_case=False)
+    model = BertModel.from_pretrained(MODEL_NAME)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    model.eval()
+    protein_segments = 0
+    protein_embeddings_list = []
+    for record in records:
+        print("record:", record)
+        for feature in record.features:
+            if feature.type == "CDS":
+                nuc_seq = feature.location.extract(record.seq)
+                if len(nuc_seq) % 3 != 0:
+                    # bad cds are skipped as in
+                    # https://github.com/Nardus/zoonotic_rank/blob/main/Utils/GenomeFeatures.py#L105
+                    continue
+                this_seq = nuc_seq.translate()
+                print("this_seq:", this_seq)
+                # ProtBERT expects spaces between amino acids
+                sequence_w_spaces = " ".join(re.sub(r"[\\*~]", "", str(this_seq).upper()))
+                print("sequence_w_spaces:", sequence_w_spaces)
+                inputs = tokenizer(
+                        sequence_w_spaces,
+                        padding="max_length",
+                        max_length=2048,
+                        truncation=True,
+                        return_tensors="pt"
+                    )
+                inputs = {k: v.to(device) for k, v in inputs.items()}
+                with torch.no_grad():
+                    outputs = model(**inputs)
+                sequence_embeddings = outputs.last_hidden_state[0]
+                # Remove special tokens [CLS] and [SEP]
+                seq_len = len(this_seq)
+                token_embeddings = sequence_embeddings[1:seq_len+1]  # shape: (seq_len, 1024)
+                # perform mean pooling of the embeddings:
+                # should produce mean embeddings with shape (1024,)
+                protein_embeddings = token_embeddings.mean(dim=0)
+                protein_embeddings_list.append(protein_embeddings)
+                protein_segments += 1
+                # confirmed shape: torch.Size([1024])
+                print("protein_embeddings.shape:", protein_embeddings.shape)
+    print(f"{protein_segments=}")
+    mean_embedding_this_virus = torch.stack(protein_embeddings_list).mean(dim=0)
+    print("mean_embedding_this_virus.shape:", mean_embedding_this_virus.shape)
+    print("end of get_bert_embeddings")
+    return mean_embedding_this_virus.cpu()
 
 
 def get_gc(records):

--- a/viral_seq/analysis/spillover_predict.py
+++ b/viral_seq/analysis/spillover_predict.py
@@ -1,7 +1,7 @@
 import json
 import pickle
 from pathlib import Path
-from viral_seq.analysis.get_features import get_genomic_features, get_kmers, get_gc
+from viral_seq.analysis.get_features import get_genomic_features, get_kmers, get_gc, get_bert_embeddings
 from tqdm import tqdm
 from Bio import Entrez, SeqIO
 import numpy as np
@@ -307,7 +307,20 @@ def _populate_kmer_dict(kmer, records, features, kmer_type="AA"):
             features.update(this_res)
 
 
-def _grab_features(features, records, genomic, kmers, kmer_k, gc, kmers_pc, kmer_k_pc):
+def _populate_bert_dict(records, features):
+    print("start of _populate_bert_dict")
+    mean_embeddings = get_bert_embeddings(records)
+    features["BERT_mean_pooled"] = mean_embeddings
+    print("end of _populate_bert_dict")
+            #features.update(this_res)
+
+
+def _grab_features(features, records, genomic, kmers, kmer_k, gc, kmers_pc, kmer_k_pc, *, bert=False):
+    if bert:
+        # the ProtBert features are used as an alternative to
+        # all other features, so just add them in and return
+        _populate_bert_dict(records=records, features=features)
+        return features
     feat_genomic = None
     feat_gc = None
     if genomic:
@@ -368,6 +381,7 @@ def build_table(
     num_select: int = 1_000,
     random_state: int = 123456789,
     target_column: str = "Human Host",
+    bert: bool = True,
 ):
     if kmer_k is None:
         kmer_k = [10]
@@ -398,9 +412,12 @@ def build_table(
         meta_data = list(df.columns)
         for species, records in tqdm(records_dict.items()):
             features = row_dict[species].to_dict()
+            print("**species:", species)
             this_result = _grab_features(
-                features, records, genomic, kmers, kmer_k, gc, kmers_pc, kmer_k_pc
+                features, records, genomic, kmers, kmer_k, gc, kmers_pc, kmer_k_pc, bert=bert
             )
+            print(f"{species=} features['BERT_mean_pooled']:",
+                  features["BERT_mean_pooled"])
             if this_result is not None:
                 calculated_feature_rows.append(this_result)
     # human gene feature tables


### PR DESCRIPTION
* This is an early-stage/work in progress effort to address the reviewer 2 comment related to using newer models in gh-43. The specific approach being attempted here is to use ProtBert embeddings intead of all the other conventional features we were using, as described at:
https://github.com/lanl/ldrd_virus_work/issues/43#issuecomment-3693484229

* This is going to require substantial iteration to get working correctly--I'm currently using this workflow incantation to develop in a `gp160` screen session:
`time python ../viral_seq/run_workflow.py -tr Relabeled_Train_Human_Shuffled.csv -ts Relabeled_Test_Human_Shuffled.csv -tc "human" -c "extract" -n 16 -cp 1 >& log.txt`

TODO:

- [ ] get testsuite/CI passing with the new changes/dependencies (like `torch`, `transformers`, etc.)
- [ ] need to provide a command line flag to be able to turn the ProtBert features on/off
- [ ] need to run the workflow with the new ProtBert features on a few datasets, based on what makes most sense to provide/update in the manuscript
- [ ] need to make sure the plot(s) that include ProtBert features are appropriately labelled and ready for the manuscript--do we need separate plots or we can we reuse old ones with a label swap?
- [ ] may be good to also allow use of `ESM-1b` embeddings, since they were used in the EvoMIL paper described at https://github.com/lanl/ldrd_virus_work/issues/43#issuecomment-3693484229, though I may do that in a follow-up, depending on how this turns out
- [ ] remove debug prints, etc., once this is working properly in the workflow runs...